### PR TITLE
ci: use gha cache

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -35,14 +35,12 @@ jobs:
         DOCKER_BUILDKIT: 1
         REPOSITORY: 'ghcr.io/cogniq/cogniq'
       run: |
-        docker pull $REPOSITORY:main || true
-        docker pull $REPOSITORY:${{ steps.vars.outputs.image_tag }} || true
-
         docker buildx build  \
           --pull \
           --push \
-          --cache-from $REPOSITORY:main \
-          --cache-from $REPOSITORY:${{ steps.vars.outputs.image_tag }} \
+          --cache-to type=gha,mode=max,ignore-error=true \
+          --cache-from type=gha,scope=main \
+          --cache-from type=gha \
           --build-arg BUILD_TIME=$(TIMESTAMP) \
           --build-arg BUILD_VERSION=${{ steps.vars.outputs.image_tag }} \
           --build-arg BUILD_SHA=${{ steps.vars.outputs.short_sha }} \

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
 
   deploy-cogniq-community-main:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*' || github.ref == 'refs/heads/jimp/cidev'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*'
     needs:
       - build
       - vars

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,12 @@ RUN chown -R cogniq /app /tmp
 
 ENV PATH="/opt/venv/bin:$PATH"
 
-COPY pyproject.toml ./
+COPY pyproject.toml poetry.lock ./
 RUN --mount=type=cache,target=/root/.cache \
     pip install --upgrade pip && \
     pip install poetry && \
     poetry config virtualenvs.create false && \
-    poetry lock --no-interaction --no-ansi && \
-    poetry install --no-interaction --no-ansi
+    poetry install --no-interaction --no-ansi --no-root --no-directory
 
 WORKDIR /app
 


### PR DESCRIPTION

**Description of the changes**
Use the [GHA cache](https://docs.docker.com/build/cache/backends/gha/) in an attempt to speed up builds. 



**Checklist**
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes, if applicable.
- [x] I have updated the documentation, if necessary.
- [x] All new and existing tests passed.

