### PR TITLE
refactor: have a consistent signature for ask_directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project is under active development. Your experience will be buggy until a release has been cut.
 Naturally at this stage, there are no guarantees about stability.
 
-In short, the current feature set is that you can have conversations about web search results in the slack bot if you give it the "search" or "bing" keywords. Otherwise, you're talking to Chat GPT4. You can also talk to Claude.
+In short, the current feature set is that you can have conversations that will be composed of responses from Bing Search, Chat GPT, and Anthropic Claude.
 
 If you don't have access to one of the API keys required for the personality, then modify `multiple_personalities.py` to remove the personality or personalities.
 

--- a/cogniq/personalities/base_personality.py
+++ b/cogniq/personalities/base_personality.py
@@ -10,17 +10,29 @@ class BasePersonality(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def ask_task(self, *, event, reply_ts, **kwargs):
+        """
+        Ask a question of the personality and have it reply to the given channel and thread.
+        """
         pass
 
     @abc.abstractmethod
     def async_setup(self):
+        """
+        Perform any asynchronous setup tasks.
+        """
         pass
 
     @abc.abstractmethod
     def ask_directly(self, *, q, message_history, **kwargs):
+        """
+        Ask a question of the personality and return the response.
+        """
         pass
 
     @property
     @abc.abstractmethod
     def description(self):
+        """
+        A short description of the personality. This is used by an evaluator to note the context of the response.
+        """
         pass

--- a/cogniq/personalities/chat_anthropic/ask.py
+++ b/cogniq/personalities/chat_anthropic/ask.py
@@ -37,7 +37,8 @@ class Ask:
         self.bot_id = await self.cslack.anthropic_history.get_bot_user_id()
         self.bot_name = await self.cslack.anthropic_history.get_bot_name()
 
-    async def ask(self, *, q, message_history=""):
+    async def ask(self, *, q, message_history=None):
+        message_history = message_history or ""
         kwargs = {
             "model": "claude-instant-v1-100k",
             "max_tokens_to_sample": 100000,

--- a/cogniq/personalities/chat_anthropic/chat_anthropic.py
+++ b/cogniq/personalities/chat_anthropic/chat_anthropic.py
@@ -55,8 +55,9 @@ class ChatAnthropic(BasePersonality):
         """
         Ask directly to the personality.
         """
+        # Convert the message history from OpenAI to Anthropic format
         message_history = self.cslack.anthropic_history.openai_to_anthropic(
-            message_history
+            message_history=message_history
         )
         response = await self.ask.ask(q=q, message_history=message_history, **kwargs)
         return response

--- a/cogniq/personalities/chat_anthropic/chat_anthropic.py
+++ b/cogniq/personalities/chat_anthropic/chat_anthropic.py
@@ -2,8 +2,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-import re
-
 
 from cogniq.personalities import BasePersonality
 from cogniq.slack import CogniqSlack
@@ -53,10 +51,13 @@ class ChatAnthropic(BasePersonality):
             channel=channel, ts=reply_ts, text=response
         )
 
-    async def ask_directly(self, *, q, message_history, **kwargs):
+    async def ask_directly(self, *, q: str, message_history: list, **kwargs):
         """
         Ask directly to the personality.
         """
+        message_history = self.cslack.anthropic_history.openai_to_anthropic(
+            message_history
+        )
         response = await self.ask.ask(q=q, message_history=message_history, **kwargs)
         return response
 

--- a/cogniq/personalities/evaluator/evaluator.py
+++ b/cogniq/personalities/evaluator/evaluator.py
@@ -48,12 +48,10 @@ class Evaluator(BasePersonality):
         channel = event["channel"]
         message = event["text"]
 
-        openai_history = await self.cslack.openai_history.get_history(event=event)
-        anthropic_history = await self.cslack.anthropic_history.get_history(event=event)
+        message_history = await self.cslack.openai_history.get_history(event=event)
         openai_response = await self.ask.ask(
             q=message,
-            openai_history=openai_history,
-            anthropic_history=anthropic_history,
+            message_history=message_history,
             personalities=personalities,
         )
         # logger.debug(openai_response)
@@ -61,18 +59,12 @@ class Evaluator(BasePersonality):
             channel=channel, ts=reply_ts, text=openai_response
         )
 
-    async def ask_directly(
-        self, *, q, openai_history, anthropic_history, personalities, **kwargs
-    ):
+    async def ask_directly(self, *, q, message_history, personalities, **kwargs):
         """
         Ask directly to the personality.
         """
         response = await self.ask.ask(
-            q=q,
-            openai_history=openai_history,
-            anthropic_history=anthropic_history,
-            personalities=personalities,
-            **kwargs
+            q=q, message_history=message_history, personalities=personalities, **kwargs
         )
         return response
 

--- a/cogniq/slack/history/anthropic_history.py
+++ b/cogniq/slack/history/anthropic_history.py
@@ -22,12 +22,12 @@ class AnthropicHistory(OpenAIHistory):
                         chat_sequence += f"\n\nHuman: {reply.get('text')}"
         return chat_sequence
 
-    def openai_to_anthropic(self, *, openai_chat_history):
+    def openai_to_anthropic(self, *, message_history):
         # Initialize an empty list to store the messages
         messages = []
 
         # Iterate over the chat history
-        for message in openai_chat_history:
+        for message in message_history:
             # Extract the role and content from the message
             role = message["role"]
             content = message["content"]

--- a/cogniq/slack/history/anthropic_history.py
+++ b/cogniq/slack/history/anthropic_history.py
@@ -3,6 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from .openai_history import OpenAIHistory
+from cogniq.openai import system_message, user_message, assistant_message
 
 
 class AnthropicHistory(OpenAIHistory):
@@ -20,3 +21,25 @@ class AnthropicHistory(OpenAIHistory):
                     else:
                         chat_sequence += f"\n\nHuman: {reply.get('text')}"
         return chat_sequence
+
+    def openai_to_anthropic(self, *, openai_chat_history):
+        # Initialize an empty list to store the messages
+        messages = []
+
+        # Iterate over the chat history
+        for message in openai_chat_history:
+            # Extract the role and content from the message
+            role = message["role"]
+            content = message["content"]
+
+            # Add the message to the list
+            if role == "user":
+                messages.append(f"Human: {content}")
+            elif role == "assistant":
+                messages.append(f"Assistant: {content}")
+            elif role == "system":
+                messages.append(f"Human: {content}")
+
+        # Convert the list of messages to the Anthropic format
+        anthropic_chat_history = "\n\n".join(messages)
+        return anthropic_chat_history

--- a/multiple_personalities.py
+++ b/multiple_personalities.py
@@ -75,6 +75,7 @@ class MultiplePersonalities:
         personalities = [
             self.chat_gpt4,
             self.bing_search,
+            self.chat_anthropic,
         ]
 
         _evaluation_task = asyncio.create_task(


### PR DESCRIPTION

**Description of the changes**
Standardize on shipping around OpenAI format message_history. 
Anthropic based personalities can then use the helper function to convert to anthropic message history.

**Related issue(s)**
fixes #45


**Testing**

Validated that the anthropic personality was able to operate.
```
2023-06-03 17:42:41,067 - cogniq.personalities.chat_anthropic.ask - INFO - res: ["Okay, here are the detailed steps to install CUDA Toolkit 12:\n\n1. Check system requirements:\n\n- 64-bit Windows 10, Linux, or macOS\n- CUDA-capable GPU (Kepler, Maxwell, Pascal, Volta, Turing, Ampere architecture or newer)\n- Latest system updates and patches installed \n- Minimum 8 GB of RAM (16 GB recommended)\n\n2. Download the CUDA Toolkit 12 installer from NVIDIA's website:\n\n- Windows: CUDA Toolkit 12.0 Update 1 -> Windows (exe)\n- Linux: CUDA Toolkit 12.0 -> Linux (run) \n- macOS: CUDA Toolkit 12.0 -> Mac (pkg)\n\n3. Install the Toolkit:\n\n- Windows: Double-click the .exe file and follow the prompts. \n- Linux: From the terminal, run the .run file with sudo and follow prompts.\n- macOS: Double-"]
```


**Checklist**
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes, if applicable.
- [x] I have updated the documentation, if necessary.
- [x] All new and existing tests passed.

