### PR TITLE
fix: rotate tokens upon expiry

### DIFF
--- a/cogniq/slack/cogniq_slack.py
+++ b/cogniq/slack/cogniq_slack.py
@@ -70,7 +70,6 @@ class CogniqSlack:
             oauth_settings=AsyncOAuthSettings(
                 client_id=self.config["SLACK_CLIENT_ID"],
                 client_secret=self.config["SLACK_CLIENT_SECRET"],
-                state_store=self.state_store,
                 scopes=[
                     "app_mentions:read",
                     "channels:history",
@@ -80,6 +79,10 @@ class CogniqSlack:
                     "mpim:history",
                 ],
                 user_scopes=["search:read"],
+                installation_store=self.installation_store,
+                token_rotation_expiration_minutes=60*9,
+                state_store=self.state_store,
+                logger=logger,
             ),
         )
         self.app_handler = AsyncSlackRequestHandler(self.app)

--- a/cogniq/slack/cogniq_slack.py
+++ b/cogniq/slack/cogniq_slack.py
@@ -80,7 +80,7 @@ class CogniqSlack:
                 ],
                 user_scopes=["search:read"],
                 installation_store=self.installation_store,
-                token_rotation_expiration_minutes=60*9,
+                token_rotation_expiration_minutes=60 * 9,
                 state_store=self.state_store,
                 logger=logger,
             ),


### PR DESCRIPTION

**Description of the changes**
Fixes a bug where tokens were not being rotated. 

The OAuth settings needs the installation and state stores to properly handle token rotation.

**Related issue(s)**
fixes #72

**Testing**
works in RamTank dev. 

**Checklist**
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes, if applicable.
- [x] I have updated the documentation, if necessary.
- [x] All new and existing tests passed.

