### PR TITLE
fix: oauth state_store should be offset-naive, like slack-bolt library

### DIFF
--- a/cogniq/slack/state_store.py
+++ b/cogniq/slack/state_store.py
@@ -48,7 +48,7 @@ class StateStore(AsyncOAuthStateStore):
         try:
             async with self.engine.begin() as conn:
                 c = self.oauth_states.c
-                query = self.oauth_states.select().where(and_(c.state == state, c.expire_at > datetime.now(timezone.utc))).limit(1)
+                query = self.oauth_states.select().where(and_(c.state == state, c.expire_at > datetime.now())).limit(1)
                 result = await conn.execute(query)
                 row = result.one_or_none()
                 logger.debug(f"consume's query result: {row}")


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: ''
labels: ''
assignees: 'jim80net'

---

**Description of the changes**
Removes timestamp from datetime.now() in state store. 

**Related issue(s)**
Fixes #91 

**Testing**
![image](https://github.com/CogniQ/CogniQ/assets/176915/08ba3193-501b-4bdd-9023-19c620a03bb4)
It works on my laptop.....

**Deployment Steps**
- [ ] Merge to main
-
**Screenshots**
If applicable, add screenshots to help explain your changes.

**Checklist**
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes, if applicable.
- [x] I have updated the documentation, if necessary.
- [ ] All new and existing tests passed.

